### PR TITLE
Fixing syntax on exception

### DIFF
--- a/notification/logentries_msg.py
+++ b/notification/logentries_msg.py
@@ -93,7 +93,7 @@ def main():
 
     try:
         send_msg(module, token, msg, api, port)
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg="unable to send msg: %s" % e)
 
     changed = True


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ansible-modules / notifications / logentries_msg


##### SUMMARY
Fixing syntax error on try/except as only python3 syntax is supported.
This is for the already existing PR in ansible-modules-extra(https://github.com/ansible/ansible-modules-extras/pull/904)

If you can merge this fix, it will allow me to finish up the above issue.

